### PR TITLE
Quote URLs

### DIFF
--- a/src/opensemanticetl/etl_web.py
+++ b/src/opensemanticetl/etl_web.py
@@ -146,7 +146,8 @@ class Connector_Web(Connector_File):
 			# if no protocol, add http://
 			if not uri.lower().startswith("http://") and not uri.lower().startswith("https://") and not uri.lower().startswith("ftp://") and not uri.lower().startswith("ftps://"):
 				uri = 'http://' + uri
-		
+			uri = urllib.parse.quote(uri)
+			uri = uri.replace('%3A',':')
 			parameters['id'] = uri
 
 			


### PR DESCRIPTION
URLs those contain none English characters should be quoted.

Please review the code and see if there is a better option to quote URLs like this.
I tried to index the following URL.
`https://www.nimrokh.tv/news/38938/دلال-بازی-تلگرامچی-بی-مخاطب-سینمایی`
API and console, both failed to index.
`http://192.168.1.154/search-apps/api/index-web?uri=https://www.nimrokh.tv/news/38938/دلال-بازی-تلگرامچی-بی-مخاطب-سینمایی`
