### PR TITLE
Updated the py2neo version to use v3

### DIFF
--- a/build/deb/stable/DEBIAN/postinst
+++ b/build/deb/stable/DEBIAN/postinst
@@ -6,7 +6,7 @@ adduser --system --disabled-password opensemanticetl
 pip3 install scrapy
 
 # install py2neo
-pip3 install py2neo
+pip3 install py2neo==3.1.2
 
 # install warcio
 pip3 install warcio


### PR DESCRIPTION
The latest version of py2neo, v4 has breaking changes in API and hence the export_neo4j.py is not working.
When this dependency was uninstalled and the version 3.1.2 was installed, the functionality worked!