### PR TITLE
Fix shebang line in build-deb

### DIFF
--- a/build-deb
+++ b/build-deb
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 
 VERSION=`date +%y.%m.%d`
 PACKAGE=open-semantic-etl_${VERSION}.deb


### PR DESCRIPTION
This fixes the shebang line for the `build-deb` script.