### PR TITLE
point py2neo to archived tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ ARG FROM=debian:bullseye
 FROM ${FROM}
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
 RUN apt-get update && apt-get install --no-install-recommends --yes \
     build-essential \
@@ -31,6 +30,11 @@ RUN apt-get update && apt-get install --no-install-recommends --yes \
     tesseract-ocr \
 #    tesseract-ocr-all \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install rust to build cryptography libraries
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 
 COPY ./src/opensemanticetl/requirements.txt /usr/lib/python3/dist-packages/opensemanticetl/requirements.txt
 # install Python PIP dependecies

--- a/src/opensemanticetl/requirements.txt
+++ b/src/opensemanticetl/requirements.txt
@@ -1,4 +1,4 @@
-py2neo
+https://github.com/technige/py2neo/archive/refs/tags/py2neo-3.1.2.zip
 scrapy
 warcio
 tika


### PR DESCRIPTION
This is a workaround to solve the issue #143 , py2neo does no longer publish version 3.1.2. This pull request changes the requirement to point directly to the archived library.
This workaround should be temporary until someone with the knowledge to do it can upgrade the library to a newer version.

It also modifies the Dockerfile to add the rust compiler needed to build the cryptography library. It is a dependency by the scrapy library and the former option `CRYPTOGRAPHY_DONT_BUILD_RUST=1` does not work anymore in the new versions (https://cryptography.io/en/3.4.5/installation.html#building-cryptography-on-linux).

Future possible enhancements of these two commits:

* Update py2neo library to a new and supported one
* Use a build intermediate container to avoid having rust in the runtime container