### PR TITLE
Overlooked one setting when adjusting to new Celery API (PR#146)

### DIFF
--- a/src/opensemanticetl/tasks.py
+++ b/src/opensemanticetl/tasks.py
@@ -40,7 +40,7 @@ app.conf.task_acks_late = True
 # so used CPUs/threads can be more than that setting!
 
 if os.getenv('OPEN_SEMANTIC_ETL_CONCURRENCY'):
-    app.conf.CELERYD_CONCURRENCY = os.getenv('OPEN_SEMANTIC_ETL_CONCURRENCY')
+    app.conf.worker_concurrency = int(os.getenv('OPEN_SEMANTIC_ETL_CONCURRENCY'))
 
 
 etl_delete = Delete()


### PR DESCRIPTION
celery.exceptions.ImproperlyConfigured:

Cannot mix new and old setting keys, please rename the
following settings to the new format:

CELERYD_CONCURRENCY                  -> worker_concurrency