### PR TITLE
Fix quadratic performance behavior of enhance_extract_money

### DIFF
--- a/src/opensemanticetl/enhance_extract_money.py
+++ b/src/opensemanticetl/enhance_extract_money.py
@@ -21,6 +21,8 @@ class enhance_extract_money(etl_plugin_core.Plugin):
         if data is None:
             data = {}
 
+        moneys = set(data.get('money_ss', []))
+
         text = etl_plugin_core.get_text(data)
         text = text.replace("\n", " ")
 
@@ -47,10 +49,12 @@ class enhance_extract_money(etl_plugin_core.Plugin):
 
         rule = regex_part_number + '\s?' + regex_part_currencies
         for match in re.finditer(rule, text, re.IGNORECASE):
-            etl_plugin_core.append(data, 'money_ss', match.group(0))
+            moneys.add(match.group(0))
 
         rule = regex_part_currencies + '\s?' + regex_part_number
         for match in re.finditer(rule, text, re.IGNORECASE):
-            etl_plugin_core.append(data, 'money_ss', match.group(0))
+            moneys.add(match.group(0))
+
+        data['money_ss'] = list(moneys)
 
         return parameters, data


### PR DESCRIPTION
The way enhance_extract_money was implemented it had O(n²) performance, which lead to very poor performance with large documents with large numbers of money figures. We've seen cases where processing took hours.

The problem resided in its use of `etl_plugin_core.append()` for every money amount found, which deduplicates the list of facets and takes longer and longer with each added value.

This patch changes it to collect all values in a `set` and then add them in bulk at the end.