### PR TITLE
Fix docker race between the apps and etl container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY ./src/tesseract-ocr-cache/tesseract_fake /usr/lib/python3/dist-packages/tes
 COPY ./src/open-semantic-entity-search-api/src/entity_linking /usr/lib/python3/dist-packages/entity_linking
 COPY ./src/open-semantic-entity-search-api/src/entity_manager /usr/lib/python3/dist-packages/entity_manager
 
-COPY ./etc/opensemanticsearch /etc/opensemanticsearch
+COPY docker-entrypoint.sh /
 
 # add user
 RUN adduser --system --disabled-password opensemanticetl
@@ -52,4 +52,4 @@ RUN chown opensemanticetl /var/cache/tesseract
 USER opensemanticetl
 
 # start Open Semantic ETL celery workers (reading and executing ETL tasks from message queue)
-CMD ["/usr/bin/python3", "/usr/lib/python3/dist-packages/opensemanticetl/tasks.py"]
+CMD ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+
+# docker-entrypoint for opensemanticsearch/open-semantic-etl
+
+# wait for the apps container to finish initializing:
+while ! curl -m 1 -sf http://apps >/dev/null 2>&1
+do
+	sleep 1
+done
+
+exec /usr/bin/python3 /usr/lib/python3/dist-packages/opensemanticetl/tasks.py


### PR DESCRIPTION
When starting the containers for the first time, docker will use the first container that starts to fill the /etc/opensemanticsearch volume.

This volume should not be initialized like this and the apps container has been updated to reflect that. In this commit we make sure we do not inadvertently initialize it from the etl container either.

The new entrypoint script also waits until the apps container is finished initializing the configuration and database.